### PR TITLE
Add a set height in to logo to prevent iOS/Safari bug.

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -91,6 +91,7 @@ export default {
   
   &__logo { 
     width: 120px;
+    height: 120px;
     display: block;
   }
 


### PR DESCRIPTION
This fixes issue 16, where the logo was displaying too tall.