### PR TITLE
Make the network attribution footer area fit on smaller mobile devices.

### DIFF
--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -73,11 +73,20 @@ footer {
     justify-content: center;
     width: 100%;
     margin-top: 2rem;
+    font-size: 10px;
+
+    @media (min-width: $breakpoint-xs) {
+      font-size: $body-font-sm;
+    }
   }
 
   &__network-logo {
-    max-width: 100px;
+    max-width: 70px;
     margin: 0 1rem -3px 1rem;
+
+    @media (min-width: $breakpoint-xs) {
+      max-width: 100px;
+    }
   }
 }
 </style>

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -23,5 +23,6 @@ $h1-size: 28px;
 $section-padding-mobile: 4rem 1rem;
 
 // breakpoints
+$breakpoint-xs: 400px;
 $breakpoint-sm: 678px;
 $breakpoint-md: 780px;


### PR DESCRIPTION
Noticed that the footer wraps a little on iPhone.  Just shrinking things down so it fits.