### PR TITLE
config: Enable redirect for RSS feed

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/subscribe/rss"
+  to = "https://feeds.fireside.fm/enjoy-the-vue/rss"
+  status = 301
+  force = false


### PR DESCRIPTION
https://docs.netlify.com/configure-builds/file-based-configuration/#redirects

The idea is we could use our custom domain for sharing easy to remember links, but it will redirect to Fireside for analytic purposes.