### PR TITLE
Remove templates option from gridsome config to allow for natural dynamic routing.

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -38,12 +38,4 @@ module.exports = {
       }
     }
   ],
-  templates: {
-    Episode: [
-      {
-        path: "/episodes/1",
-        component: "./src/templates/Episode.vue"
-      }
-    ]
-  }
 };


### PR DESCRIPTION
I think the issue was that I over-complicated this in the first place.  Removing the template option works locally on the first episode and when I staged a second test episode.