### PR TITLE
Figure out panelists

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -44,10 +44,10 @@ collections:
         name: "picks"
         widget: "object"
         fields: 
-          - {label: "Chris picks", name: "chris-picks", widget: "markdown"}
-          - {label: "Ben picks", name: "ben-picks", widget: "markdown"}
-          - {label: "Ari picks", name: "ari-picks", widget: "markdown"}
-          - {label: "Elizabeth picks", name: "elizabeth-picks", widget: "markdown"}
+          - {label: "Chris picks", name: "chris-picks", widget: "markdown", required: "false"}
+          - {label: "Ben picks", name: "ben-picks", widget: "markdown", required: "false"}
+          - {label: "Ari picks", name: "ari-picks", widget: "markdown", required: "false"}
+          - {label: "Elizabeth picks", name: "elizabeth-picks", widget: "markdown", required: "false"}
       - {label: "Shownotes", name: "shownotes", widget: "markdown"}
       - {label: "Transcript", name: "transcript", widget: "markdown"}
 

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -11,7 +11,6 @@ collections:
     label: "Panelists"
     folder: "panelists"
     create: true
-    slug: "{{slug}}"
     identifier_field: name
     fields:
       - {label: "Name", name: "name", widget: "string"}
@@ -45,10 +44,10 @@ collections:
         name: "picks"
         widget: "object"
         fields: 
-          - {label: "Chris picks", name: "chris-fritz-picks", widget: "list"}
-          - {label: "Ben picks", name: "ben-hong-picks", widget: "list"}
-          - {label: "Ari picks", name: "ari-clark-picks", widget: "list"}
-          - {label: "Elizabeth picks", name: "elizabeth-fine-picks", widget: "list"}
+          - {label: "Chris picks", name: "chris-picks", widget: "list"}
+          - {label: "Ben picks", name: "ben-picks", widget: "list"}
+          - {label: "Ari picks", name: "ari-picks", widget: "list"}
+          - {label: "Elizabeth picks", name: "elizabeth-picks", widget: "list"}
       - {label: "Shownotes", name: "shownotes", widget: "markdown"}
       - {label: "Transcript", name: "transcript", widget: "markdown"}
 

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -44,10 +44,10 @@ collections:
         name: "picks"
         widget: "object"
         fields: 
-          - {label: "Chris picks", name: "chris-picks", widget: "list"}
-          - {label: "Ben picks", name: "ben-picks", widget: "list"}
-          - {label: "Ari picks", name: "ari-picks", widget: "list"}
-          - {label: "Elizabeth picks", name: "elizabeth-picks", widget: "list"}
+          - {label: "Chris picks", name: "chris-picks", widget: "markdown"}
+          - {label: "Ben picks", name: "ben-picks", widget: "markdown"}
+          - {label: "Ari picks", name: "ari-picks", widget: "markdown"}
+          - {label: "Elizabeth picks", name: "elizabeth-picks", widget: "markdown"}
       - {label: "Shownotes", name: "shownotes", widget: "markdown"}
       - {label: "Transcript", name: "transcript", widget: "markdown"}
 

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -11,6 +11,7 @@ collections:
     label: "Panelists"
     folder: "panelists"
     create: true
+    slug: "{{slug}}"
     identifier_field: name
     fields:
       - {label: "Name", name: "name", widget: "string"}
@@ -44,10 +45,10 @@ collections:
         name: "picks"
         widget: "object"
         fields: 
-          - {label: "Chris picks", name: "chris-picks", widget: "markdown"}
-          - {label: "Ben picks", name: "ben-picks", widget: "markdown"}
-          - {label: "Ari picks", name: "ari-picks", widget: "markdown"}
-          - {label: "Elizabeth picks", name: "elizabeth-picks", widget: "markdown"}
+          - {label: "Chris picks", name: "chris-fritz-picks", widget: "list"}
+          - {label: "Ben picks", name: "ben-hong-picks", widget: "list"}
+          - {label: "Ari picks", name: "ari-clark-picks", widget: "list"}
+          - {label: "Elizabeth picks", name: "elizabeth-fine-picks", widget: "list"}
       - {label: "Shownotes", name: "shownotes", widget: "markdown"}
       - {label: "Transcript", name: "transcript", widget: "markdown"}
 

--- a/src/components/Panelists.vue
+++ b/src/components/Panelists.vue
@@ -56,30 +56,23 @@ export default {
 			required: false,
 			default: () => {},
 		},
+		onlyShowPanelistsWithPicks: {
+			type: Boolean,
+			required: false,
+			default: false,
+		},
 	},
 	computed: {
 		panelists() {
 			const panelists = this.$static.posts.edges.map((panelist) => {
-				// eeehh...this isnt great but until we can implement a cms solution for this
-				// we need to just map the picks to the panelists here,
-				let picks = [];
-				const name = panelist.node.name.toLowerCase();
-				if (name === 'elizabeth fine'){
-					picks = this.picks ? this.picks.elizabeth : [];
-				} else if (name === 'ben hong') {
-					picks = this.picks ? this.picks.ben : [];
-				} else if (name === 'ari clark') {
-					picks = this.picks ? this.picks.ari : [];
-				} else if (name === 'chris fritz') {
-					picks = this.picks ? this.picks.chris : [];
-				}
+				const name = panelist.node.name;
+				const image = panelist.node.image;
+				const website = panelist.node.website;
+				const firstName = name.replace(/ .*/,'').toLowerCase();
+				const picks = this.picks ? this.picks.firstName : [];
 
-				return {
-					name: panelist.node.name,
-					image: panelist.node.image,
-					website: panelist.node.website,
-					picks: picks,
-				}
+				if (this.onlyShowPanelistsWithPicks && !picks) return; 
+				return { name, image, website, picks }
 			});
 			return panelists;
 		},

--- a/src/components/Panelists.vue
+++ b/src/components/Panelists.vue
@@ -64,17 +64,20 @@ export default {
 	},
 	computed: {
 		panelists() {
-			const panelists = this.$static.posts.edges.map((panelist) => {
+			const allPanelists = this.$static.posts.edges.map((panelist) => {
 				const name = panelist.node.name;
 				const image = panelist.node.image;
 				const website = panelist.node.website;
 				const firstName = name.replace(/ .*/,'').toLowerCase();
-				const picks = this.picks ? this.picks.firstName : [];
-
-				if (this.onlyShowPanelistsWithPicks && !picks) return; 
+				const picks = this.picks ? this.picks[firstName] : [];
 				return { name, image, website, picks }
 			});
-			return panelists;
+
+			const panelistsWithPicks = allPanelists.filter((panelist) => {
+				return panelist.picks.length;
+			});
+
+			return this.onlyShowPanelistsWithPicks ? panelistsWithPicks : allPanelists;
 		},
 	}
 };

--- a/src/templates/Episode.vue
+++ b/src/templates/Episode.vue
@@ -45,6 +45,7 @@
           <h2>Our picks this week</h2>
           <panelists
             :picks="picks"
+            only-show-panelists-with-picks
             class="episode__panelists"
           />
         </div>
@@ -135,10 +136,10 @@ export default {
     picks() {
       const { chris_picks, ben_picks, ari_picks, elizabeth_picks } = this.$page.episode.picks;
       return {
-        chris: [...chris_picks.split(',')],
-        ben: [...ben_picks.split(',')],
-        ari: [...ari_picks.split(',')],
-        elizabeth: [...elizabeth_picks.split(',')],
+        chris: chris_picks.length ? [...chris_picks.split(',')] : [],
+        ben: ben_picks.length ? [...ben_picks.split(',')] : [],
+        ari: ari_picks.length ? [...ari_picks.split(',')] : [],
+        elizabeth: elizabeth_picks.length ? [...elizabeth_picks.split(',')] : [],
       };
     },
     compiledTranscript() {

--- a/src/templates/Episode.vue
+++ b/src/templates/Episode.vue
@@ -135,10 +135,10 @@ export default {
     picks() {
       const { chris_picks, ben_picks, ari_picks, elizabeth_picks } = this.$page.episode.picks;
       return {
-        chris: chris_picks,
-        ben: ben_picks,
-        ari: ari_picks,
-        elizabeth: elizabeth_picks,
+        chris: [...chris_picks.split(',')],
+        ben: [...ben_picks.split(',')],
+        ari: [...ari_picks.split(',')],
+        elizabeth: [...elizabeth_picks.split(',')],
       };
     },
     compiledTranscript() {

--- a/src/templates/Episode.vue
+++ b/src/templates/Episode.vue
@@ -135,10 +135,10 @@ export default {
     picks() {
       const { chris_picks, ben_picks, ari_picks, elizabeth_picks } = this.$page.episode.picks;
       return {
-        chris: [...chris_picks.split(', ')],
-        ben: [...ben_picks.split(', ')],
-        ari: [...ari_picks.split(', ')],
-        elizabeth: [...elizabeth_picks.split(', ')],
+        chris: chris_picks,
+        ben: ben_picks,
+        ari: ari_picks,
+        elizabeth: elizabeth_picks,
       };
     },
     compiledTranscript() {


### PR DESCRIPTION
Initially started to create a custom Netlify CMS widget for this but that opened a can of worms. This seems like a cleaner solution for now.

This way if a panelist doesnt have any picks inputted for them in the CMS, they will not appear on the episode page (indicating that they were not there for that episode).  If they were there for the episode but simply had no picks, we should indicate it by putting "No pick this week" as their pick.