### PR TITLE
chore: configure cron action to trigger netlify deployment

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -1,0 +1,13 @@
+on:
+  schedule:
+    - cron: '55 5 * * 1'
+
+jobs:
+  netlify:
+    runs-on: ubuntu-latest
+    name: Deploy on Mondays
+    env:
+      NETLIFY_DEPLOYMENT_TRIGGER: ${{ secrets.NETLIFY_DEPLOYMENT_TRIGGER }}
+    steps:
+      - name: Trigger Netlify deployment
+        run: curl ${NETLIFY_DEPLOYMENT_TRIGGER}


### PR DESCRIPTION
This PR configures a Github action to trigger Netlify deployment at 05:55 every Monday (cron expression: [55 5 * * 1](https://crontab.guru/#55_5_*_*_1)).

Fixes: #138 

**NOTE:**

Create a build hook from Netlify deployment settings and set the hook URL as a repository secret with the name: `NETLIFY_DEPLOYMENT_TRIGGER`.

<img width="935" alt="image" src="https://user-images.githubusercontent.com/2596484/78213844-69c92c00-74d1-11ea-8ddf-6a0ebae1899c.png">
