### PR TITLE
155 consolidate audio download link

### DIFF
--- a/episodes/1.md
+++ b/episodes/1.md
@@ -6,7 +6,7 @@ cover-art: /uploads/episode-1.jpg
 sharing-link: 'https://fireside.fm/s/iAt1uZwr+S5N5bzIz'
 rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
-  https://media.fireside.fm/file/fireside-audio/podcasts/audio/4/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/episodes/2/203541ee-ca89-450b-817e-217b4e2061fb/203541ee-ca89-450b-817e-217b4e2061fb.mp3
+  https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/203541ee-ca89-450b-817e-217b4e2061fb.mp3
 sponsor: Linode
 picks:
   - person: Chris Fritz

--- a/episodes/1.md
+++ b/episodes/1.md
@@ -4,8 +4,7 @@ episode-title: 'Welcome to the Vue: Meet your Panel!'
 date-published: 2020-01-27T14:00:23.569Z
 cover-art: /uploads/episode-1.jpg
 sharing-link: 'https://fireside.fm/s/iAt1uZwr+S5N5bzIz'
-download-link: >-
-  https://media.fireside.fm/file/fireside-audio/podcasts/audio/4/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/episodes/2/203541ee-ca89-450b-817e-217b4e2061fb/203541ee-ca89-450b-817e-217b4e2061fb.mp3
+rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://media.fireside.fm/file/fireside-audio/podcasts/audio/4/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/episodes/2/203541ee-ca89-450b-817e-217b4e2061fb/203541ee-ca89-450b-817e-217b4e2061fb.mp3
 sponsor: Linode

--- a/episodes/10.md
+++ b/episodes/10.md
@@ -4,7 +4,7 @@ episode-title: Web Accessibility with Maria Lamardo
 date-published: 2020-03-30T10:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-10.png
 sharing-link: 'https://fireside.fm/s/iAt1uZwr+Y7GnGPvt'
-download-link: "https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/b5d3d549-40a3-4761-bdc0-2bd28803ef56.mp3\t"
+rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: "https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/b5d3d549-40a3-4761-bdc0-2bd28803ef56.mp3\t"
 sponsor: Linode
 picks:

--- a/episodes/10.md
+++ b/episodes/10.md
@@ -5,7 +5,8 @@ date-published: 2020-03-30T10:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-10.png
 sharing-link: 'https://fireside.fm/s/iAt1uZwr+Y7GnGPvt'
 rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
-audio-link: "https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/b5d3d549-40a3-4761-bdc0-2bd28803ef56.mp3\t"
+audio-link: >-
+  https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/b5d3d549-40a3-4761-bdc0-2bd28803ef56.mp3
 sponsor: Linode
 picks:
   - person: Chris Fritz

--- a/episodes/11.md
+++ b/episodes/11.md
@@ -4,8 +4,7 @@ episode-title: Test Driven Development (feat. Sarah Dayan)
 date-published: 2020-04-06T13:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-11.png
 sharing-link: 'https://enjoythevue.io/episodes/11'
-download-link: >-
-  https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/39e14f8d-e5fc-4c0a-929f-0bda2ee9265c.mp3
+rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/39e14f8d-e5fc-4c0a-929f-0bda2ee9265c.mp3
 sponsor: Linode

--- a/episodes/12.md
+++ b/episodes/12.md
@@ -4,8 +4,7 @@ episode-title: Vue Router with Eduardo San Martin Morote
 date-published: 2020-04-13T10:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-12.png
 sharing-link: 'https://fireside.fm/s/iAt1uZwr+KUqjovKk'
-download-link: >-
-  https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/36ea6a8f-1982-4011-b9b1-cad094cfca6f.mp3
+rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/36ea6a8f-1982-4011-b9b1-cad094cfca6f.mp3
 sponsor: Linode

--- a/episodes/2.md
+++ b/episodes/2.md
@@ -4,8 +4,7 @@ episode-title: What We Love About Vue CLI
 date-published: 2020-02-03T14:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-2.png
 sharing-link: 'https://fireside.fm/s/iAt1uZwr+S5N5bzIz'
-download-link: >-
-  https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/f9968a54-cce2-49a7-b15f-03a7a5af0f1d.mp3
+rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/f9968a54-cce2-49a7-b15f-03a7a5af0f1d.mp3
 sponsor: Linode

--- a/episodes/3.md
+++ b/episodes/3.md
@@ -4,8 +4,7 @@ episode-title: 'VV Day, DevRel & More with Jen Looper'
 date-published: 2020-02-10T14:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-3.png
 sharing-link: 'https://fireside.fm/s/iAt1uZwr+b2mmmeaX'
-download-link: >-
-  https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/3d218c4b-c5c1-49b8-8d0e-c0910cab0834.mp3
+rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/3d218c4b-c5c1-49b8-8d0e-c0910cab0834.mp3
 sponsor: Linode

--- a/episodes/4.md
+++ b/episodes/4.md
@@ -4,8 +4,7 @@ episode-title: 'JAMming, MCing, Vuex & More with Divya Sasidharan'
 date-published: 2020-02-17T16:25:52.261Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-4.png
 sharing-link: 'https://www.enjoythevue.io/episodes/4'
-download-link: >-
-  https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/0823ce6d-6840-4e98-b153-289f0178c534.mp3
+rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/0823ce6d-6840-4e98-b153-289f0178c534.mp3
 sponsor: Linode

--- a/episodes/5.md
+++ b/episodes/5.md
@@ -4,8 +4,7 @@ episode-title: 'Productivity Tools, Workflows & Tabs vs Spaces'
 date-published: 2020-02-25T13:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-5.png
 sharing-link: 'https://www.enjoythevue.io/episodes/5'
-download-link: >-
-  https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/bb3b182e-5a0e-474c-9edb-abbe0c26e3b9.mp3
+rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/bb3b182e-5a0e-474c-9edb-abbe0c26e3b9.mp3
 sponsor: Linode

--- a/episodes/6.md
+++ b/episodes/6.md
@@ -4,8 +4,7 @@ episode-title: May the Forms be with You (feat. Marina Mosti)
 date-published: 2020-03-02T21:23:52.572Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-6.png
 sharing-link: 'https://www.enjoythevue.io/episodes/6/'
-download-link: >-
-  https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/ebea7a82-444b-4511-8e5f-be7d3b459a0e.mp3
+rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/ebea7a82-444b-4511-8e5f-be7d3b459a0e.mp3
 sponsor: Linode

--- a/episodes/7.md
+++ b/episodes/7.md
@@ -3,8 +3,8 @@ episode-number: 7
 episode-title: Workshops 101
 date-published: 2020-03-10T13:30:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-7.png
-download-link: >-
-  https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/9390c5be-2d2a-4fbf-bb6a-5be25b37b9b5.mp3
+sharing-link: 'https://www.enjoythevue.io/episodes/7/'
+rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/9390c5be-2d2a-4fbf-bb6a-5be25b37b9b5.mp3
 sponsor: Linode

--- a/episodes/8.md
+++ b/episodes/8.md
@@ -4,8 +4,7 @@ episode-title: Vue's Education Philosophy Brought to Schools (feat. Hope Wilder)
 date-published: 2020-03-16T13:02:07.645Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-8.png
 sharing-link: 'https://www.enjoythevue.io/episodes/8/'
-download-link: >-
-  https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/b38f18f6-b220-416d-847c-178080e86f37.mp3
+rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/b38f18f6-b220-416d-847c-178080e86f37.mp3
 sponsor: Linode

--- a/episodes/9.md
+++ b/episodes/9.md
@@ -6,8 +6,7 @@ episode-title: >-
 date-published: 2020-03-23T13:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-9.png
 sharing-link: 'https://www.enjoythevue.io/episodes/9'
-download-link: >-
-  https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/22bbcf7d-c5f4-44e2-b22a-e12e976c94e6.mp3
+rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/22bbcf7d-c5f4-44e2-b22a-e12e976c94e6.mp3
 sponsor: Linode

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -46,7 +46,12 @@ collections:
       - { label: 'Date published', name: 'date-published', widget: 'datetime' }
       - { label: 'Cover art', name: 'cover-art', widget: 'image' }
       - { label: 'Sharing link', name: 'sharing-link', widget: 'string' }
-      - { label: 'Download link', name: 'download-link', widget: 'string' }
+      - {
+          label: 'RSS link',
+          name: 'rss-link',
+          widget: 'string',
+          default: 'https://feeds.fireside.fm/enjoy-the-vue/rss',
+        }
       - { label: 'Audio link', name: 'audio-link', widget: 'string' }
       - label: 'Sponsor'
         name: 'sponsor'

--- a/src/components/MediaPlayer.vue
+++ b/src/components/MediaPlayer.vue
@@ -18,11 +18,6 @@ export default {
       required: false,
       default: ''
     },
-    downloadLink: {
-      type: String,
-      required: false,
-      default: ''
-    },
     sharingLink: {
       type: String,
       required: false,
@@ -167,7 +162,7 @@ export default {
         />
         <div class="media__links">
           <a v-if="sharingLink" :href="sharingLink">Share</a>
-          <a v-if="downloadLink" :href="downloadLink">Download</a>
+          <a v-if="audioLink" :href="audioLink">Download</a>
           <a v-if="rssLink" :href="rssLink" target="_blank">Subscribe</a>
         </div>
       </div>

--- a/src/templates/Episode.vue
+++ b/src/templates/Episode.vue
@@ -13,8 +13,7 @@
               :episode-number="$page.episode.episode_number"
               :cover-art-src="$page.episode.cover_art"
               :sharing-link="$page.episode.sharing_link"
-              :download-link="$page.episode.download_link"
-              :rss-link="rssLink"
+              :rss-link="$page.episode.rss_link"
               :audio-link="$page.episode.audio_link"
             />
           </div>
@@ -69,7 +68,7 @@ query ($id: ID!) {
     date_published
     cover_art
     sharing_link
-    download_link
+    rss_link
     audio_link
     sponsor
     picks {


### PR DESCRIPTION
I realized that the Audio and Download URL were identical so I thought it'd save us the effort of copying it twice.

I was also going to try and refactor the URL to only include the unique ID since all of the URLs have a similar path, but I realized this would make it harder to copy since when we copy it's the full URL (and we'd have to make a specific effort to only grab the mp3 file name which is error prone).