### PR TITLE
Make latestEpisodeUrl on homepage use latestEpisodeNumber

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -51,8 +51,7 @@ export default {
       )[0];
     },
     latestEpisodeUrl() {
-      // TODO: Fix so it is dynamic
-      return `/episodes/11`;
+      return `/episodes/${latestEpisodeNumber}`;
     },
   },
 };

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -51,7 +51,7 @@ export default {
       )[0];
     },
     latestEpisodeUrl() {
-      return `/episodes/${latestEpisodeNumber}`;
+      return `/episodes/${this.latestEpisodeNumber}`;
     },
   },
 };


### PR DESCRIPTION
So it is always updated.  I thought this was already working, but I guess it isnt. I wonder if it broke during a merge or conflict resolution or something.  Anyway, there is still an open to-do to check whether the episode is truly published or not.

https://deploy-preview-190--enjoythevue.netlify.app/