### PR TITLE
fix (#115): resolve random panelist glitch by sorting via alphabetical

### DIFF
--- a/src/components/Panelists.vue
+++ b/src/components/Panelists.vue
@@ -78,14 +78,19 @@ export default {
   },
   computed: {
     panelists() {
-      const allPanelists = this.$static.posts.edges.map(panelist => {
-        const name = panelist.node.name;
-        const image = panelist.node.image;
-        const website = panelist.node.website;
-        const firstName = name.replace(/ .*/, '').toLowerCase();
-        const picks = this.picks ? this.picks[firstName] : [];
-        return { name, image, website, picks };
-      });
+      const allPanelists = this.$static.posts.edges
+        .map(panelist => {
+          const name = panelist.node.name;
+          const image = panelist.node.image;
+          const website = panelist.node.website;
+          const firstName = name.replace(/ .*/, '').toLowerCase();
+          const picks = this.picks ? this.picks[firstName] : [];
+          return { name, image, website, picks };
+        })
+        .sort((a, b) => {
+          // sort in alphabetical order
+          return a.name > b.name ? 1 : -1;
+        });
 
       const panelistsWithPicks = allPanelists.filter(panelist => {
         return panelist.picks;
@@ -93,7 +98,7 @@ export default {
 
       return this.onlyShowPanelistsWithPicks
         ? panelistsWithPicks
-        : shuffle(allPanelists);
+        : allPanelists;
     }
   }
 };


### PR DESCRIPTION
There's this weird glitch with how the Gridsome app is caching the panelist but not the photos? Anyhow, ordering it by alphabetical order since the random thing isn't working out at the moment.