### PR TITLE
Issue 228 multiple sponsors

### DIFF
--- a/episodes/1.md
+++ b/episodes/1.md
@@ -5,7 +5,8 @@ date-published: 2020-01-27T14:00:23.569Z
 cover-art: /uploads/episode-1.jpg
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/203541ee-ca89-450b-817e-217b4e2061fb.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Chris Fritz
     picks:

--- a/episodes/10.md
+++ b/episodes/10.md
@@ -5,7 +5,8 @@ date-published: 2020-03-30T10:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-10.png
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/b5d3d549-40a3-4761-bdc0-2bd28803ef56.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Chris Fritz
     picks:

--- a/episodes/11.md
+++ b/episodes/11.md
@@ -5,7 +5,8 @@ date-published: 2020-04-06T13:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-11.png
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/39e14f8d-e5fc-4c0a-929f-0bda2ee9265c.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Ari Clark
     picks:

--- a/episodes/12.md
+++ b/episodes/12.md
@@ -5,7 +5,8 @@ date-published: 2020-04-13T10:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-12.png
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/36ea6a8f-1982-4011-b9b1-cad094cfca6f.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Ari Clark
     picks:

--- a/episodes/13.md
+++ b/episodes/13.md
@@ -7,7 +7,8 @@ sharing-link: 'https://enjoythevue.io/episodes/13'
 rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/5e97aada-2584-4c3e-97a6-835c64cea714.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Ari Clark
     picks:

--- a/episodes/14.md
+++ b/episodes/14.md
@@ -7,7 +7,8 @@ sharing-link: 'https://enjoythevue.io/episodes/14'
 rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/e95a1e3a-c2bb-4061-aa86-8f0fe8f7a786.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Ari Clark
     picks:

--- a/episodes/15.md
+++ b/episodes/15.md
@@ -7,7 +7,8 @@ sharing-link: 'https://enjoythevue.io/episodes/15'
 rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/68adfe24-ec8e-4ccf-ab1a-5e268bcf6239.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Ari Clark
     picks:

--- a/episodes/16.md
+++ b/episodes/16.md
@@ -6,7 +6,8 @@ cover-art: /uploads/enjoy-the-vue-cover-ep-16.png
 rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/c2e896f1-d5c7-405f-bcc8-c2a8bef50bc8.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Chris Fritz
     picks:

--- a/episodes/17.md
+++ b/episodes/17.md
@@ -6,7 +6,8 @@ cover-art: /uploads/enjoy-the-vue-cover-ep-17.png
 rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/4b277712-0312-4004-8501-2372646ef701.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Ben Hong
     picks:

--- a/episodes/18.md
+++ b/episodes/18.md
@@ -6,7 +6,8 @@ cover-art: /uploads/enjoy-the-vue-cover-ep-18.png
 rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/6e4481a3-4043-4924-98a7-362b6837ef71.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Ben Hong
     picks:

--- a/episodes/19.md
+++ b/episodes/19.md
@@ -6,7 +6,8 @@ cover-art: /uploads/enjoy-the-vue-cover-ep-19.png
 rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/a1e02547-4305-46d5-bfaa-740ee12b4a60.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Ben Hong
     picks:

--- a/episodes/2.md
+++ b/episodes/2.md
@@ -5,7 +5,8 @@ date-published: 2020-02-03T14:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-2.png
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/f9968a54-cce2-49a7-b15f-03a7a5af0f1d.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Chris Fritz
     picks:

--- a/episodes/20.md
+++ b/episodes/20.md
@@ -6,7 +6,8 @@ cover-art: /uploads/enjoy-the-vue-cover-ep-20.png
 rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/d903aa96-11b0-4585-939b-32d56dab6cdf.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Ben Hong
     picks:

--- a/episodes/21.md
+++ b/episodes/21.md
@@ -6,7 +6,9 @@ cover-art: /uploads/enjoy-the-vue-cover-ep-21.png
 rss-link: 'https://feeds.fireside.fm/enjoy-the-vue/rss'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/b6d7affb-65d2-4c4f-96c7-df7975691432.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
+  - sponsor: Segment
 picks:
   - person: Ben Hong
     picks:

--- a/episodes/3.md
+++ b/episodes/3.md
@@ -5,7 +5,8 @@ date-published: 2020-02-10T14:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-3.png
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/3d218c4b-c5c1-49b8-8d0e-c0910cab0834.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Chris Fritz
     picks:

--- a/episodes/4.md
+++ b/episodes/4.md
@@ -5,7 +5,8 @@ date-published: 2020-02-17T16:25:52.261Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-4.png
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/0823ce6d-6840-4e98-b153-289f0178c534.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Chris Fritz
     picks:

--- a/episodes/5.md
+++ b/episodes/5.md
@@ -5,7 +5,8 @@ date-published: 2020-02-25T13:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-5.png
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/bb3b182e-5a0e-474c-9edb-abbe0c26e3b9.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Chris Fritz
     picks:

--- a/episodes/6.md
+++ b/episodes/6.md
@@ -5,7 +5,8 @@ date-published: 2020-03-02T21:23:52.572Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-6.png
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/ebea7a82-444b-4511-8e5f-be7d3b459a0e.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Ben Hong
     picks:

--- a/episodes/7.md
+++ b/episodes/7.md
@@ -6,7 +6,8 @@ cover-art: /uploads/enjoy-the-vue-cover-ep-7.png
 sharing-link: 'https://www.enjoythevue.io/episodes/7/'
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/9390c5be-2d2a-4fbf-bb6a-5be25b37b9b5.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Chris Fritz
     picks:

--- a/episodes/8.md
+++ b/episodes/8.md
@@ -5,7 +5,8 @@ date-published: 2020-03-16T13:02:07.645Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-8.png
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/b38f18f6-b220-416d-847c-178080e86f37.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Ari Clark
     picks:

--- a/episodes/9.md
+++ b/episodes/9.md
@@ -7,7 +7,8 @@ date-published: 2020-03-23T13:00:00.000Z
 cover-art: /uploads/enjoy-the-vue-cover-ep-9.png
 audio-link: >-
   https://aphid.fireside.fm/d/1437767933/41abfd1d-87a1-43d7-94d9-7fda3a5120e1/22bbcf7d-c5f4-44e2-b22a-e12e976c94e6.mp3
-sponsor: Linode
+sponsors: 
+  - sponsor: Linode
 picks:
   - person: Chris Fritz
     picks:

--- a/sponsors/linode.md
+++ b/sponsors/linode.md
@@ -2,7 +2,8 @@
 sponsor-name: Linode
 sponsor-logo: /uploads/linode-logo.png
 sponsor-link: 'https://promo.linode.com/vue'
-sponsor-offer-details: >-
+sponsor-content-title: Special offer - $20 off
+sponsor-content-details: >-
   An exclusive offer for Enjoy the Vue listeners, sign up today and use promo
   code 'VUE2020' to receive $20 towards your new account.
 sponsor-offer-code: VUE2020

--- a/sponsors/segment.md
+++ b/sponsors/segment.md
@@ -2,8 +2,7 @@
 sponsor-name: Segment
 sponsor-logo: /uploads/segment-vector-logo.svg
 sponsor-link: 'https://segment.com/?ref=codefund-podcast-etv'
-sponsor-offer-details: >-
+sponsor-content-details: >-
   Segment is a customer data platform that makes good data accessible for all
   teams.
-sponsor-offer-code: None
 ---

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -28,9 +28,15 @@ collections:
       - { label: 'Sponsor name', name: 'sponsor-name', widget: 'string' }
       - { label: 'Sponsor logo', name: 'sponsor-logo', widget: 'image' }
       - { label: 'Sponsor link', name: 'sponsor-link', widget: 'string' }
+      - { 
+          label: 'Content title', 
+          name: 'sponsor-content-title', 
+          widget: 'string',
+          required: false, 
+        }
       - {
-          label: 'Offer details',
-          name: 'sponsor-offer-details',
+          label: 'Content details',
+          name: 'sponsor-content-details',
           widget: 'markdown',
           required: false,
         }
@@ -59,17 +65,17 @@ collections:
         }
       - { label: 'Audio link', name: 'audio-link', widget: 'string' }
       - label: 'Sponsors'
-        name: 'sponsor'
+        name: 'sponsors'
         widget: 'list'
         fields:
           - {
               label: 'Sponsor',
+              name: 'sponsor',
               widget: 'relation',
               collection: 'sponsors',
               searchFields: ['sponsor-name'],
               valueField: 'sponsor-name',
               displayFields: ['sponsor-name'],
-              default: 'Linode',
             }
         
       - label: 'Picks'

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -32,8 +32,14 @@ collections:
           label: 'Offer details',
           name: 'sponsor-offer-details',
           widget: 'markdown',
+          required: false,
         }
-      - { label: 'Offer code', name: 'sponsor-offer-code', widget: 'string' }
+      - {
+          label: 'Offer code',
+          name: 'sponsor-offer-code',
+          widget: 'string',
+          required: false,
+        }
   - name: 'episodes'
     label: 'Episodes'
     folder: 'episodes'
@@ -52,14 +58,20 @@ collections:
           default: 'https://feeds.fireside.fm/enjoy-the-vue/rss',
         }
       - { label: 'Audio link', name: 'audio-link', widget: 'string' }
-      - label: 'Sponsor'
+      - label: 'Sponsors'
         name: 'sponsor'
-        widget: 'relation'
-        collection: 'sponsors'
-        searchFields: ['sponsor-name']
-        valueField: 'sponsor-name'
-        displayFields: ['sponsor-name']
-        default: 'Linode'
+        widget: 'list'
+        fields:
+          - {
+              label: 'Sponsor',
+              widget: 'relation',
+              collection: 'sponsors',
+              searchFields: ['sponsor-name'],
+              valueField: 'sponsor-name',
+              displayFields: ['sponsor-name'],
+              default: 'Linode',
+            }
+        
       - label: 'Picks'
         name: 'picks'
         widget: 'list'

--- a/src/components/SponsorshipBox.vue
+++ b/src/components/SponsorshipBox.vue
@@ -8,13 +8,13 @@
         class="sponsorship__logo"
       />
     </a>
-    <div class="sponsorship__offer">
-      <div class="sponsorship__offer-inner">
+    <div class="sponsorship__details">
+      <div class="sponsorship__details-inner">
         <span
           v-if="contentTitle"
-          class="sponsorship__offer-label">{{ contentTitle }}</span>
+          class="sponsorship__content-title">{{ contentTitle }}</span>
 
-        <p class="sponsorship__offer-content">{{ content }}</p>
+        <p class="sponsorship__content">{{ content }}</p>
         <span v-if="code" class="sponsorship__offer-code"
           >Code: {{ code }}</span
         >
@@ -76,7 +76,7 @@ export default {
   }
 
   &__image,
-  &__offer {
+  &__details {
     width: 100%;
     display: flex;
     justify-content: flex-start;
@@ -88,7 +88,7 @@ export default {
     }
   }
 
-  &__offer {
+  &__details {
     background: transparent;
     border-left: none;
 
@@ -114,20 +114,20 @@ export default {
     }
   }
 
-  &__offer-inner {
+  &__details-inner {
     @media (min-width: $breakpoint-sm) {
       padding-left: 4rem;
       max-width: 300px;
     }
   }
 
-  &__offer-label {
+  &__content-title {
     font-size: $body-font-lg;
     font-family: $font-main;
     display: block;
   }
 
-  &__offer-content {
+  &__content {
     font-size: $body-font-sm;
     font-family: $font-secondary;
   }

--- a/src/components/SponsorshipBox.vue
+++ b/src/components/SponsorshipBox.vue
@@ -10,7 +10,9 @@
     </a>
     <div class="sponsorship__offer">
       <div class="sponsorship__offer-inner">
-        <span class="sponsorship__offer-label">Special offer - $20 off</span>
+        <span
+          v-if="contentTitle"
+          class="sponsorship__offer-label">{{ contentTitle }}</span>
 
         <p class="sponsorship__offer-content">{{ content }}</p>
         <span v-if="code" class="sponsorship__offer-code"
@@ -39,6 +41,11 @@ export default {
       required: false,
       default: '#'
     },
+    contentTitle: {
+      type: String,
+      required: false,
+      default: ''
+    },
     content: {
       type: String,
       required: false,
@@ -59,6 +66,10 @@ export default {
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;
+
+  & + .sponsorship {
+    margin-top: 4rem;
+  }
 
   @media (min-width: $breakpoint-sm) {
     flex-wrap: nowrap;
@@ -99,7 +110,8 @@ export default {
     margin-bottom: 2rem;
 
     @media (min-width: $breakpoint-sm) {
-      height: 80px;
+      height: auto;
+      max-width: 200px;
       margin-bottom: auto;
     }
   }

--- a/src/components/SponsorshipBox.vue
+++ b/src/components/SponsorshipBox.vue
@@ -104,14 +104,12 @@ export default {
   }
 
   &__logo {
-    height: 70px;
+    height: auto;
+    max-width: 200px;
     padding-right: 4rem;
-    // margin: 2rem auto;
     margin-bottom: 2rem;
 
     @media (min-width: $breakpoint-sm) {
-      height: auto;
-      max-width: 200px;
       margin-bottom: auto;
     }
   }

--- a/src/templates/Episode.vue
+++ b/src/templates/Episode.vue
@@ -25,10 +25,13 @@
         <div class="container__section-inner">
           <h2>This episode is sponsored by...</h2>
           <sponsorship-box
+            v-for="sponsor in sponsors"
+            :key="sponsor.sponsor_name"
             :name="sponsor.sponsor_name"
             :logoSrc="sponsor.sponsor_logo"
             :link="sponsor.sponsor_link"
-            :content="sponsor.sponsor_offer_details"
+            :content-title="sponsor.sponsor_content_title"
+            :content="sponsor.sponsor_content_details"
             :code="sponsor.sponsor_offer_code"
           />
         </div>
@@ -70,7 +73,9 @@ query ($id: ID!) {
     cover_art
     sharing_link
     audio_link
-    sponsor
+    sponsors {
+      sponsor
+    }
     picks {
       person 
       picks {
@@ -87,7 +92,8 @@ query ($id: ID!) {
         sponsor_name
         sponsor_logo
         sponsor_link
-        sponsor_offer_details
+        sponsor_content_title
+        sponsor_content_details
         sponsor_offer_code
       }
     }
@@ -164,13 +170,14 @@ export default {
     sharingLink() {
       return `https://www.enjoythevue.io/episodes/${this.$page.episode.episode_number}`;
     },
-    sponsor() {
-      const sponsorEdge = this.$page.allSponsor.edges.filter(
-        edge => edge.node['sponsor_name'] === this.$page.episode.sponsor
-      )[0];
-
-      return sponsorEdge.node;
-    }
+    sponsors() {
+      const episodeSponsors = this.$page.episode.sponsors.map(s => s.sponsor);
+      return this.$page.allSponsor.edges
+        .filter((sponsor) => {
+          return episodeSponsors.includes(sponsor.node['sponsor_name']);
+        })
+        .map(sponsor => sponsor.node);
+    },
   }
 };
 </script>


### PR DESCRIPTION
- Adds ability to list multiple sponsors on episode page.
- Updates components to accept sponsors in this new data format.
- Slightly makes the logos smaller for episode sponsors. They were pretty big anyway and this makes it easier to look at when there are two.
- Updates all old content files to use new data format for sponsors.
- Makes offer code and offer title optional.

Deploy preview: https://deploy-preview-233--enjoythevue.netlify.app/episodes/21/