### PR TITLE
Remove reference to the rebase.fm network

### DIFF
--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -4,13 +4,6 @@
     <slot />
     <footer class="footer">
       <social-links class="footer__social-links" />
-      <div class="footer__network">
-        <p>
-          Part of the
-          <a href="https://www.rebase.fm/" target="_blank">rebase.fm</a> Podcast
-          Network
-        </p>
-      </div>
     </footer>
   </div>
 </template>


### PR DESCRIPTION
Footer currently still references the rebase.fm network that we are no longer a part of. We should probably remove that.