### PR TITLE
Update Panelists.vue to accept a prop to only show current panelists.

### DIFF
--- a/panelists/alex.md
+++ b/panelists/alex.md
@@ -2,4 +2,5 @@
 name: Alex Riviere
 website: 'https://twitter.com/fimion'
 image: /uploads/alex-bio.jpg
+current: true
 ---

--- a/panelists/ari-clark.md
+++ b/panelists/ari-clark.md
@@ -2,5 +2,6 @@
 name: Ari Clark
 website: 'https://twitter.com/gloomyLumi'
 image: /uploads/ari-bio.jpeg
+current: true
 ---
 

--- a/panelists/tessa.md
+++ b/panelists/tessa.md
@@ -1,4 +1,5 @@
 ---
 name: Tessa
 image: /uploads/tessa-bio.jpg
+current: true
 ---

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -19,6 +19,7 @@ collections:
       - { label: 'Name', name: 'name', widget: 'string' }
       - { label: 'Website', name: 'website', widget: 'string' }
       - { label: 'Image', name: 'image', widget: 'image' }
+      - { label: 'Currently Hosting', name: 'current', widget: 'boolean', default: false }
   - name: 'sponsors'
     label: 'Sponsors'
     folder: 'sponsors'

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -19,7 +19,7 @@ collections:
       - { label: 'Name', name: 'name', widget: 'string' }
       - { label: 'Website', name: 'website', widget: 'string' }
       - { label: 'Image', name: 'image', widget: 'image' }
-      - { label: 'Currently Hosting', name: 'current', widget: 'boolean', default: false }
+      - { label: 'Current', name: 'current', widget: 'boolean', default: false }
   - name: 'sponsors'
     label: 'Sponsors'
     folder: 'sponsors'

--- a/src/components/Panelists.vue
+++ b/src/components/Panelists.vue
@@ -54,6 +54,7 @@ query {
 				name
 				website
 				image
+        current
       }
     }
   }
@@ -85,6 +86,7 @@ export default {
     allPanelists() {
       const allPanelists = this.$static.posts.edges
         .map(panelist => {
+          console.log(panelist.node)
           const name = panelist.node.name;
           const image = panelist.node.image;
           const website = panelist.node.website;

--- a/src/components/Panelists.vue
+++ b/src/components/Panelists.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="panelists__container">
     <div
-      v-for="panelist in panelists"
+      v-for="panelist in renderedPanelists"
       :key="panelist.name"
       class="panelists__person"
     >
@@ -74,10 +74,15 @@ export default {
       type: Boolean,
       required: false,
       default: false
-    }
+    },
+    onlyShowCurrentPanelists: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
   computed: {
-    panelists() {
+    allPanelists() {
       const allPanelists = this.$static.posts.edges
         .map(panelist => {
           const name = panelist.node.name;
@@ -85,20 +90,25 @@ export default {
           const website = panelist.node.website;
           const firstName = name.replace(/ .*/, '').toLowerCase();
           const picks = this.picks ? this.picks[firstName] : [];
-          return { name, image, website, picks };
+          const current = panelist.node.current;
+          return { name, image, website, picks, current };
         })
         .sort((a, b) => {
           // sort in alphabetical order
           return a.name > b.name ? 1 : -1;
         });
-
-      const panelistsWithPicks = allPanelists.filter(panelist => {
-        return panelist.picks;
-      });
-
-      return this.onlyShowPanelistsWithPicks
-        ? panelistsWithPicks
-        : allPanelists;
+      return allPanelists;
+    },
+    panelistsWithPicks() {
+      return this.allPanelists.filter(panelist => panelist.picks);
+    },
+    currentPanelists() {
+      return this.allPanelists.filter(panelist => panelist.current);
+    },
+    renderedPanelists() {
+      if (this.onlyShowPanelistsWithPicks) return this.panelistsWithPicks;
+      if (this.onlyShowCurrentPanelists) return this.currentPanelists;
+      return this.allPanelists;
     }
   }
 };

--- a/src/components/Panelists.vue
+++ b/src/components/Panelists.vue
@@ -86,7 +86,6 @@ export default {
     allPanelists() {
       const allPanelists = this.$static.posts.edges
         .map(panelist => {
-          console.log(panelist.node)
           const name = panelist.node.name;
           const image = panelist.node.image;
           const website = panelist.node.website;

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -57,7 +57,9 @@ export default {
         </div>
         <div class="landing__panelists">
           <h2 class="landing__title">Our panelists</h2>
-          <panelists class="landing__panelists-container" />
+          <panelists
+            only-show-current-panelists
+            class="landing__panelists-container" />
         </div>
       </section>
 


### PR DESCRIPTION
- Shows all panelists by default but now has a prop to filter so we only see current hosts (as needed for the homepage).