### PR TITLE
Add more granular options for play speed in media player

### DIFF
--- a/src/components/MediaPlayer.vue
+++ b/src/components/MediaPlayer.vue
@@ -74,6 +74,11 @@ export default {
     this.player.removeEventListener('loadeddata', this.onLoad);
     this.player.removeEventListener('timeupdate', this.updateTime);
   },
+  watch: {
+    playbackRate() {
+      this.player.playbackRate = this.playbackRate;
+    }
+  },
   methods: {
     onLoad() {
       this.duration = parseInt(this.player.duration);
@@ -103,12 +108,18 @@ export default {
       return `${displayHours}${displayMinutes}:${displaySeconds}`;
     },
     changePlaybackRate() {
-      if (this.player.playbackRate === 2) {
-        this.player.playbackRate = 0.5;
+      const playbackRateSpeeds = {
+        0.5: 0.8,
+        0.8: 1,
+        1: 1.2,
+        1.2: 1.5,
+        1.5: 2
+      }
+
+      if (this.playbackRate === 2) {
         this.playbackRate = 0.5;
       } else {
-        this.playbackRate = this.player.playbackRate + 0.5;
-        this.player.playbackRate = this.player.playbackRate + 0.5;
+        this.playbackRate = playbackRateSpeeds[this.playbackRate];
       }
     },
     setCurrentTime(time) {

--- a/src/components/MediaPlayer.vue
+++ b/src/components/MediaPlayer.vue
@@ -113,7 +113,8 @@ export default {
         0.8: 1,
         1: 1.2,
         1.2: 1.5,
-        1.5: 2
+        1.5: 1.8,
+        1.8: 2
       }
 
       if (this.playbackRate === 2) {


### PR DESCRIPTION
closes #392

I got these numbers from the Spotify podcast interface, except I didn't add the 3x speed. I think it's extremely fast, and I also didn't want to make the list too long.

![image](https://user-images.githubusercontent.com/5460365/122684987-de6faf80-d1d6-11eb-8ccd-36413fe251f4.png)

![speed](https://user-images.githubusercontent.com/5460365/122685122-85ece200-d1d7-11eb-904c-2725593c4488.gif)
